### PR TITLE
시 군구 검색 병원 정보 반환 리스트 api 구현

### DIFF
--- a/src/main/kotlin/daelim/emergency_backend/database/EmergencyService.kt
+++ b/src/main/kotlin/daelim/emergency_backend/database/EmergencyService.kt
@@ -16,4 +16,9 @@ class EmergencyService(val emergencyRepository: EmergencyRepository, val hospita
     fun testHospital(id: String) : HospitalInformation? {
         return hospitalRepository.findById(id).orElse(null)
     }
+
+    fun searchWithCity(stage1:String, stage2:String) : List<HospitalInformation> {
+
+        return hospitalRepository.findByAddress(stage1,stage2);
+    }
 }

--- a/src/main/kotlin/daelim/emergency_backend/database/hospitalInformation/HospitalRepository.kt
+++ b/src/main/kotlin/daelim/emergency_backend/database/hospitalInformation/HospitalRepository.kt
@@ -1,5 +1,11 @@
 package daelim.emergency_backend.database.hospitalInformation
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface HospitalRepository:JpaRepository<HospitalInformation, String> {}
+interface HospitalRepository:JpaRepository<HospitalInformation, String> {
+
+    @Query("SELECT hi FROM HospitalInformation hi WHERE hi.dutyAddr LIKE %:stage1% AND hi.dutyAddr LIKE %:stage2%")
+    fun findByAddress(stage1:String, stage2:String): List<HospitalInformation>
+
+}

--- a/src/main/kotlin/daelim/emergency_backend/test/TestController.kt
+++ b/src/main/kotlin/daelim/emergency_backend/test/TestController.kt
@@ -13,6 +13,7 @@ import daelim.emergency_backend.models.TraumaCenterBasicInfo.TraumaCenterBasicIn
 import daelim.emergency_backend.models.TraumaCenterListResult
 import daelim.emergency_backend.models.TraumaCenterLocation.TraumaCenterLocationResult
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -75,6 +76,15 @@ class TestController(val testService: TestService, val emergencyService: Emergen
     fun getHostipalList():AvailableBedInfoResult {
 
         return AvailableBedInfoResult(header = null, body = null)
+    }
+
+    //시군구 검색으로 병원 정보 리스트 반환하기
+    @GetMapping("/getHospitalInfoByAddr")
+    fun getByAddress(
+        @RequestParam stage1:String,
+        @RequestParam stage2:String
+    ):List<HospitalInformation>?{
+        return emergencyService.searchWithCity(stage1, stage2)
     }
 
 }


### PR DESCRIPTION
검색어 예시
stage1 : 서울특별시, 경기도, 강원도, 충정북도 등등
stage2 : 강남구, 서초구, 노원구, 군포시, 원주시 등등

hospital_information 테이블의 duty_addr 열에 각 두 단어가 포함되어있는지 아닌지 확인하여 반환합니다.
둘 다 값이 필수로 들어가야하며, 하나라도 비어있으면 작동하지 않습니다.